### PR TITLE
forget wumpus locally, fixed some bugs

### DIFF
--- a/environment/entities/agent.py
+++ b/environment/entities/agent.py
@@ -78,7 +78,7 @@ class Agent(Entity):
         self.memory["arrow_target"] = None
 
         self.reveal_initial_cell()
-        self.perceive()
+        # self.perceive()
 
     def __str__(self):
         return f"Agent at {self.position}"
@@ -186,6 +186,8 @@ class Agent(Entity):
             )
             return None
 
+
+
         # check neighbors for perceptions
         for x, y in neumann_neighborhood(pos[0], pos[1], self.environment.size):
             # only visited cells can have perceptions in memory
@@ -262,8 +264,9 @@ class Agent(Entity):
         if self.memory["arrow_target"]:
             if self.position == self.memory["arrow_target"]:
                 # TODO: maybe shout as own action, but how to transfer data (message)?
-                self.shout("wumpus killed")
-                self.forget_wumpus()
+                self.shout(f"wumpus killed: {self.position}")
+                self.memory["arrow_target"] = None
+                self.forget_wumpus(self.position)
             else:
                 return (
                     f"move_{get_direction(self.position, self.memory['arrow_target'])}"
@@ -572,16 +575,28 @@ class Agent(Entity):
                 # do not add add pos to reserved neighbors
 
             case "wumpus killed":
-                self.forget_wumpus()
+                self.forget_wumpus(pos)
 
         # TODO: Implement response to the whisper
         # TODO: Implement negotiation logic based on the message
 
-    def forget_wumpus(self):
+    def forget_wumpus(self, pos):
         """
-        Removes everything related to the wumpus from memory
+        Removes everything related to the wumpus from memory at given position
+
+        Parameters:
+        -----------
+        pos: tuple
+            where the wumpus was killed
         """
-        for key in self.memory:
-            if isinstance(key, tuple):
-                self.memory[key]["wumpus"] = 0.0
-                self.memory[key]["stench"] = 0
+
+        if pos in self.memory:
+            self.memory[pos]["wumpus"] = 0.0
+            self.memory[pos]["stench"] = 0
+
+        for cell_pos in neumann_neighborhood(
+            self.position[0], self.position[1], self.environment.size
+        ):
+            if cell_pos in self.memory:
+                self.memory[cell_pos]["wumpus"] = 0.0
+                self.memory[cell_pos]["stench"] = 0

--- a/environment/environment.py
+++ b/environment/environment.py
@@ -40,10 +40,13 @@ class Environment:
         # Entities defined first will be placed first
         self.entity_counts = {Wumpus: 1, Gold: 10, Pit: 10, Agent: 5}
 
-        self.place_entities()
+        # self.place_entities()
 
         # pre-determined test field:
         # self.place_entity(Agent, 0, 0)
+        # self.place_entity(Agent, 3, 0)
+        # self.place_entity(Wumpus, 1, 0)
+        # self.place_entity(Wumpus, 0, 3)
         # self.place_entity(Pit, 2, 0)
         # self.place_entity(Pit, 4, 0)
         # self.place_entity(Gold, 0, 3)

--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ class WumpusGame:
         self.all_agents = []
 
         # Interval for calling the act function (default 1 second)
-        self.act_interval = 1000  # milliseconds
+        self.act_interval = 500 #1000  # milliseconds
         self.last_act_time = 0  # last time the act function was called
 
         self.DEBUG = True
@@ -253,7 +253,6 @@ class WumpusGame:
 
                 self.check_agent_status()
                 self.draw_environment()
-            # print('step')
             clock.tick(30)
             await asyncio.sleep(0)
 


### PR DESCRIPTION
wumpus im Memory wird für jeden dort entfernt wo er getötet wurde (pos wird im shout übermittelt)

fixed bugs:
- initial precieve entfernt (gab noch keine perceptions und wird sowieso jedes mal gemacht)
- es gab einen movement fehler nachdem der wumpus getötet wurde (hatte mit dem turn zu tun)