### PR TITLE
fixed: movement and a lot of bugs closes #16

### DIFF
--- a/environment/entities/gold.py
+++ b/environment/entities/gold.py
@@ -60,6 +60,6 @@ class Gold(Entity):
             agent.perceive()
 
         if interaction_type == "collect":
-            print("Agent collected a gold!")
+            print(f"{agent} collected a gold!")
             agent.score += self.reward
             self.die()

--- a/environment/entities/wumpus.py
+++ b/environment/entities/wumpus.py
@@ -49,12 +49,12 @@ class Wumpus(Entity):
             The type of interaction (e.g., "neutral", "attack").
         """
         if interaction_type == "neutral":
-            print("Agent has been killed by a Wumpus!")
+            print(f"                                                     !!!!!! {agent} has been killed by a Wumpus !!!!!!")
             agent.die()
             self.revial()
 
         elif interaction_type == "attack":
-            print("Agent killed a Wumpus!")
+            print(f"{agent} killed a Wumpus!")
             agent.score += self.reward
             self.revial()
             self.die()

--- a/environment/environment.py
+++ b/environment/environment.py
@@ -38,9 +38,9 @@ class Environment:
         self.grid = [[Cell() for _ in range(size)] for _ in range(size)]
         self.entities = []
         # Entities defined first will be placed first
-        self.entity_counts = {Wumpus: 1, Gold: 10, Pit: 10, Agent: 5}
+        self.entity_counts = {Wumpus: 3, Gold: 10, Pit: 10, Agent: 5}
 
-        # self.place_entities()
+        self.place_entities()
 
         # pre-determined test field:
         # self.place_entity(Agent, 0, 0)

--- a/helpers/neighborhood.py
+++ b/helpers/neighborhood.py
@@ -80,12 +80,13 @@ def whisper_neighborhood(x, y, size):
     list
         A list of (x, y) tuples representing the neighboring positions.
     """
+
     moore_neighbors = moore_neighborhood(x, y, size, multiplier=1)
     neumann_neighbors_2 = neumann_neighborhood(x, y, size, multiplier=2)
     neumann_neighbors_1 = neumann_neighborhood(x, y, size, multiplier=1)
 
-    # Combine the two neighborhoods and remove duplicates
+    # Combine the two neighborhoods and remove duplicates (set does this automaticly)
     combined_neighbors = list(
-        set(moore_neighbors + neumann_neighbors_2) - set(neumann_neighbors_1)
+        set(moore_neighbors + neumann_neighbors_2) # - set(neumann_neighbors_1)
     )
     return combined_neighbors

--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ class WumpusGame:
         self.all_agents = []
 
         # Interval for calling the act function (default 1 second)
-        self.act_interval = 500 #1000  # milliseconds
+        self.act_interval = 300 #1000  # milliseconds
         self.last_act_time = 0  # last time the act function was called
 
         self.DEBUG = True


### PR DESCRIPTION
Folgendes wurde behoben:
- sie kuscheln nicht mehr, jede Intention zum Bewegen und rufen nach Hilfe (momentan erstmal als flüstern nach Hilfe implementiert) gibt jetzt auch den eigenen Standort mit und so kann verhindert werden, dass Agenten ihnen unbekannte Felder aufdecken wollen, wo bereits ein anderer Agent wartet.
- die wisper_neighborhood hatte Lücken (genau die neumann neighborhood), weshalb direkte Nachbarn Nachrichten nicht empfangen konnten.
- es gab einen Fehler bei den Agenten in den Wumpus gelaufen sind. Und zwar genau dann, wenn zwei wumpus nebeneinander waren und der eine getötet wurde. Dadurch wurde natürlich alles vom einen entfernt, aber der andere ist ja auch noch da. Lösung: nicht entfernen, sondern Wahrscheinlichkeit und `visited` im Memory zurücksetzen, sodass Agenten neu erkunden und evaluieren